### PR TITLE
Avoid passing null to strtoupper()

### DIFF
--- a/optparse.php
+++ b/optparse.php
@@ -1028,7 +1028,7 @@ class Option {
         $this->metavar = _array_pop_elem(
             $settings,
             "metavar",
-            strtoupper($this->dest)
+            strtoupper($this->dest === null ? '' : $this->dest)
         );
 
         $this->nargs = _array_pop_elem($settings, "nargs", $this->nargs);


### PR DESCRIPTION
This is another effort to make this library more compatible with PHP 8.